### PR TITLE
   Fix currency conversion crash for undefined currency codes

### DIFF
--- a/Workflow/convert-currency
+++ b/Workflow/convert-currency
@@ -202,7 +202,6 @@ function fetchRates(ratesURL, ratesFile) {
     WST: "Samoan Tālā",
     XAF: "Central African Franc",
     XCD: "East Caribbean Dollar",
-    XCG: "Caribbean Guilder",
     XDR: "Special Drawing Rights",
     XOF: "West African Franc",
     XPF: "CFP Franc",
@@ -214,6 +213,11 @@ function fetchRates(ratesURL, ratesFile) {
 
   // Transform new object for searching
   const unorderedRatesObj = Object.keys(currencies).reduce((allCurrencies, currentCurrency) => {
+    // Skip currencies that don't have names defined
+    if (!currencyNames[currentCurrency]) {
+      return allCurrencies
+    }
+    
     const splitName = currencyNames[currentCurrency].split(" ")
 
     allCurrencies[currentCurrency] = {
@@ -223,7 +227,7 @@ function fetchRates(ratesURL, ratesFile) {
     }
 
     return allCurrencies
-  }, currencies)
+  }, {})
 
   // Bubble popular currencies to the top
   const ratesObj = Object.assign(
@@ -240,12 +244,6 @@ function run(argv) {
   const ratesFile = `${envVar("alfred_workflow_cache")}/ratesUSD.json`
   const ratesURL = "https://open.er-api.com/v6/latest/USD"
   const currencies = fetchRates(ratesURL, ratesFile)
-
-  const formatter = $.NSNumberFormatter.alloc.init
-  formatter.numberStyle = $.NSNumberFormatterDecimalStyle
-  formatter.minmumFractionDigits = 0
-  formatter.maximumFractionDigits = 2
-  formatter.hasThousandSeparators = envVar("thousands_group") === "1"
 
   const interpretedInput = argv[0].replace(/ (to|in|as) /i, " ").toLowerCase()
   const rawNumber = interpretedInput.replace(/^(\d*(\.\d+)?)\D*/, "$1")
@@ -300,13 +298,13 @@ function run(argv) {
   return JSON.stringify({ items: Object.keys(endCurrencies).flatMap(currencyCode => {
     if (currencyCode === startCurrencyCode) return []
     const convertedValue = currencies[currencyCode].rate / startCurrencies[startCurrencyCode].rate * numberValue
-    const formattedValue = formatter.stringFromNumber(convertedValue).js
+    const trimmedValue = convertedValue.toFixed(2)
 
     return {
       uid: currencyCode,
-      title: `${formattedValue} ${currencyCode}`,
+      title: `${trimmedValue} ${currencyCode}`,
       subtitle: `${startCurrencies[startCurrencyCode].country} ${startCurrencies[startCurrencyCode].coin} → ${currencies[currencyCode].country} ${currencies[currencyCode].coin}`,
-      arg: formattedValue,
+      arg: trimmedValue,
       autocomplete: `${numberValue} ${startCurrencyCode} to ${currencyCode}`,
       icon: { path: `images/flags/${currencyCode}.png` }
     }


### PR DESCRIPTION
   Add safety check to skip currencies that don't have names defined in currencyNames object. This prevents JavaScript errors when the Exchange Rate API returns new/unknown currency codes like XCG that aren't in our predefined list.

   Fixes the "TypeError: undefined is not an object" error that was causing the workflow to crash.